### PR TITLE
Added proofreader validation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 100

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,0 @@
-[MESSAGE CONTROL]
-disable = abstract-method,anomalous-backslash-in-string,invalid-all-object,lost-exception,missing-docstring,too-few-public-methods
-
-good-names = db,id
-function-rgx = [a-z_][a-z0-9_]{2,60}$
-method-rgx = [a-z_][a-z0-9_]{2,60}$

--- a/elife_api_validator/__init__.py
+++ b/elife_api_validator/__init__.py
@@ -11,4 +11,4 @@ __version__ = '0.0.1'
 SCHEMA_DIRECTORY = os.path.dirname(schemas.__file__)
 
 
-__all__ = [SCHEMA_DIRECTORY]
+__all__ = ['SCHEMA_DIRECTORY']

--- a/elife_api_validator/media_type.py
+++ b/elife_api_validator/media_type.py
@@ -24,7 +24,7 @@ class MediaType(object):
         data = content_type.split(';')
         self.type = data[0]
         if len(data) > 1:
-            self.params = self._unpack_params(data[1])
+            self.params = self._unpack_params(''.join(data[1:]))
 
     def matches_type(self, pattern: str) -> bool:
         """Accepts a regex pattern and attempts to find a match

--- a/elife_api_validator/validators/__init__.py
+++ b/elife_api_validator/validators/__init__.py
@@ -1,4 +1,4 @@
 from elife_api_validator.validators.json_validators import JSONResponseValidator
 
 
-__all__ = [JSONResponseValidator]
+__all__ = ['JSONResponseValidator']

--- a/elife_api_validator/validators/json_validators.py
+++ b/elife_api_validator/validators/json_validators.py
@@ -20,7 +20,7 @@ class Response(ABC):
 
 class JSONResponseValidator(ResponseValidator):
 
-    valid_type_pattern = 'application\/([a-z-\.]*\+)json'
+    valid_type_pattern = r'application\/([a-z-\.]*\+)json'
 
     def __init__(self, schema_finder: SchemaFinder = PathBasedSchemaFinder()) -> None:
         """
@@ -47,11 +47,11 @@ class JSONResponseValidator(ResponseValidator):
         except AttributeError:
             # handles requests.Response type
             data = response.json()
-        finally:
-            if data:
-                return data
-            else:
-                raise JSONDataNotFound('Unable to find JSON data in the response')
+
+        if not data:
+            raise JSONDataNotFound('Unable to find JSON data in the response')
+
+        return data
 
     @staticmethod
     def _format_json_str(data: str) -> str:

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -12,8 +12,9 @@ source venv/bin/activate
 pip install --requirement requirements.txt
 pip install coveralls
 
-pylint --reports=n elife_api_validator
-flake8 elife_api_validator/ test/
+pip install proofreader==0.0.2
+
+python -m proofreader elife_api_validator/ test/
 coverage run -m pytest --junitxml=build/pytest.xml
 
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/elife-api-validator) coveralls

--- a/test/test_media_type.py
+++ b/test/test_media_type.py
@@ -10,23 +10,25 @@ def test_it_can_return_correct_repr():
 def test_it_can_match_type():
     content_type = 'application/vnd.elife.article-list+json; version=1'
     media_type = MediaType(content_type)
-    assert media_type.matches_type('application\/([a-z-\.]*\+)json') is True
+    assert media_type.matches_type(r'application\/([a-z-\.]*\+)json') is True
 
 
 def test_it_will_fail_to_match_invalid_type():
     content_type = 'application/some_invalid_type+something; version=1'
     media_type = MediaType(content_type)
-    assert media_type.matches_type('application\/([a-z-\.]*\+)json') is False
+    assert media_type.matches_type(r'application\/([a-z-\.]*\+)json') is False
 
 
 def test_it_can_unpack_single_param():
-    params = 'version=1'
-    assert MediaType._unpack_params(params) == {'version': '1'}
+    content_type = 'application/vnd.elife.article-list+json; version=1'
+    media_type = MediaType(content_type)
+    assert media_type.params == {'version': '1'}
 
 
 def test_it_can_unpack_mulitple_params():
-    params = 'version=1; charset=utf-8'
-    assert MediaType._unpack_params(params) == {'version': '1', 'charset': 'utf-8'}
+    content_type = 'application/vnd.elife.article-list+json; version=1; charset=utf-8'
+    media_type = MediaType(content_type)
+    assert media_type.params == {'version': '1', 'charset': 'utf-8'}
 
 
 def test_it_can_parse_content_type_on_init():

--- a/test/test_schema_finder.py
+++ b/test/test_schema_finder.py
@@ -42,7 +42,7 @@ def test_it_should_find_schema_for_problem_json_error_response(finder):
     assert finder.find_schema_for(media_type) == schema_dir + '/error.v1.json'
 
 
-def test_it_should_find_the_correct_alternate_version_from_media_type(finder):
+def test_it_finds_the_correct_alternate_version_from_media_type(finder):
     media_type = MediaType('application/vnd.elife.valid-data+json; version=2')
     assert finder.find_schema_for(media_type) == 'test/test_schemas/valid-data.v2.json'
 

--- a/test/validators/test_json_validators.py
+++ b/test/validators/test_json_validators.py
@@ -50,7 +50,7 @@ def test_it_should_validate_a_valid_json_response(validator):
 
 def test_it_will_validate_an_error_response(validator):
     data = {
-        "title": "No route found for \"GET /invalid\": Method Not Allowed (Allow: OPTIONS)",
+        "title": r"No route found for \"GET /invalid\": Method Not Allowed (Allow: OPTIONS)",
         "type": "about:blank"
     }
     headers = {'Content-Type': 'application/problem+json'}


### PR DESCRIPTION
I have removed explicit calls to `pylint` and `flake8` in `project_tests.sh` in favor of using [proofreader](https://github.com/elifesciences/proofreader-python). 

I have done some minor refactoring to align the project with the stricter defaults provided by `proofreader`. Therefore I have removed the local `.pylintrc` and `.flake8` override files as they are no longer needed.