### PR TITLE
Add base branch name for new pull requests

### DIFF
--- a/Jenkinsfile.update-api-raml
+++ b/Jenkinsfile.update-api-raml
@@ -9,5 +9,6 @@ elifeUpdatePipeline(
         return "Updated api-raml to ${subrepositorySummary}"
     },
     'update_api_raml/',
-    true
+    true,
+    'master'
 )


### PR DESCRIPTION
Follow up to https://github.com/elifesciences/api-validator-python/pull/4 which had a default of `develop`, used on other projects but not necessarily in libraries.